### PR TITLE
refactor: update image validator to only consider "synced" images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$TARGETPLATFORM golang:1.22 AS builder
+FROM --platform=$TARGETPLATFORM golang:alpine3.19 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.devspace
+++ b/Dockerfile.devspace
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$TARGETPLATFORM golang:alpine3.18 as builder
+FROM --platform=$TARGETPLATFORM golang:alpine3.19 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.18.4
 )
 
-replace github.com/canonical/gomaasclient v0.6.0 => github.com/arturshadnik/gomaasclient v0.0.0-20240730214136-d7dd8da98797
+replace github.com/canonical/gomaasclient v0.6.0 => github.com/arturshadnik/gomaasclient v0.0.0-20240731231205-8239cfb13409
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
-github.com/arturshadnik/gomaasclient v0.0.0-20240730214136-d7dd8da98797 h1:lr8q69ZH1hcg8MdUSqg6s09XbgoWqRh9kyDcSxQl+gI=
-github.com/arturshadnik/gomaasclient v0.0.0-20240730214136-d7dd8da98797/go.mod h1:rRYH2hfLDZ7Z6LNmNBbLzwnu1wK894fznN5pbVtur/s=
+github.com/arturshadnik/gomaasclient v0.0.0-20240731231205-8239cfb13409 h1:J4cbZQZFlLZNy5nGyDyPW0/VI4bivvR0EyZiR/H9Y7k=
+github.com/arturshadnik/gomaasclient v0.0.0-20240731231205-8239cfb13409/go.mod h1:rRYH2hfLDZ7Z6LNmNBbLzwnu1wK894fznN5pbVtur/s=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/internal/controller/maasvalidator_controller_test.go
+++ b/internal/controller/maasvalidator_controller_test.go
@@ -39,6 +39,7 @@ type MockIDNSRulesService struct {
 func (b *MockBootResourcesService) Get(params *entity.BootResourcesReadParams) ([]entity.BootResource, error) {
 	return []entity.BootResource{
 		{
+			Type:         "Synced",
 			Name:         "Ubuntu",
 			Architecture: "amd64/ga-22.04",
 		},
@@ -63,7 +64,7 @@ func (m *MockMachinesService) Get(params *entity.MachinesParams) ([]entity.Machi
 	}, nil
 }
 
-func (i *MockIDNSRulesService) Get(params *entity.DNSResourcesGetParams) ([]entity.DNSResource, error) {
+func (i *MockIDNSRulesService) Get(params *entity.DNSResourcesParams) ([]entity.DNSResource, error) {
 	return []entity.DNSResource{
 		{
 			FQDN: "foo.maas.sc",

--- a/internal/validators/dns/internal_dns_validator.go
+++ b/internal/validators/dns/internal_dns_validator.go
@@ -43,13 +43,13 @@ func (s *InternalDNSRulesService) ReconcileMaasInstanceInternalDNSRule(rule v1al
 }
 
 func (s *InternalDNSRulesService) ensureDNSResources(rule v1alpha1.InternalDNSRule) ([]string, []error) {
-	details := make([]string, 0)
-	errs := make([]error, 0)
-
-	maasDNSResources, err := s.api.Get(&entity.DNSResourcesGetParams{All: true})
+	maasDNSResources, err := s.api.Get(&entity.DNSResourcesParams{All: true})
 	if err != nil {
 		return nil, []error{err}
 	}
+
+	details := make([]string, 0)
+	errs := make([]error, 0)
 
 	formattedRecords := formatDNSRecords(maasDNSResources)
 

--- a/internal/validators/dns/internal_dns_validator_test.go
+++ b/internal/validators/dns/internal_dns_validator_test.go
@@ -16,7 +16,7 @@ type DummyDNSResources struct {
 	resources []entity.DNSResource
 }
 
-func (d *DummyDNSResources) Get(params *entity.DNSResourcesGetParams) ([]entity.DNSResource, error) {
+func (d *DummyDNSResources) Get(params *entity.DNSResourcesParams) ([]entity.DNSResource, error) {
 	return d.resources, nil
 }
 

--- a/internal/validators/dns/upstream_dns_validator.go
+++ b/internal/validators/dns/upstream_dns_validator.go
@@ -45,13 +45,14 @@ func (s *UpstreamDNSRulesService) ReconcileMaasInstanceUpstreamDNSRule(rule v1al
 }
 
 func (s *UpstreamDNSRulesService) findDNSServers(expected int) ([]string, []error) {
-	details := make([]string, 0)
-	errs := make([]error, 0)
-
 	ns, err := s.api.Get("upstream_dns")
 	if err != nil {
 		return nil, []error{err}
 	}
+
+	details := make([]string, 0)
+	errs := make([]error, 0)
+
 	nameservers := strings.Split(string(ns), " ")
 	numServers := len(nameservers)
 

--- a/internal/validators/os/os_validator_test.go
+++ b/internal/validators/os/os_validator_test.go
@@ -36,6 +36,7 @@ func TestReconcileMaasInstanceImageRule(t *testing.T) {
 				&DummyBootResources{
 					images: []entity.BootResource{
 						{
+							Type:         "Synced",
 							Name:         "Ubuntu",
 							Architecture: "amd64/ga-20.04",
 						},


### PR DESCRIPTION
## Issue
Resolves #97 

## Description
- Adding a check to make sure only "Synced" images are considered for validation
- Updating DNSResource to use the updated maas API client
- Bumping base Go versions for Docker images
- Making maas API error handling more consistent
