### PR TITLE
fix: allow user to configure key for API Token

### DIFF
--- a/api/v1alpha1/maasvalidator_types.go
+++ b/api/v1alpha1/maasvalidator_types.go
@@ -40,7 +40,7 @@ func (s MaasValidatorSpec) ResultCount() int {
 // Auth provides authentication information for the MAAS Instance
 type Auth struct {
 	SecretName string `json:"secretName" yaml:"secretName"`
-	TokenKey   string `json:"token" yaml:"token"`
+	TokenKey   string `json:"tokenKey" yaml:"tokenKey"`
 }
 
 // ImageRule defines a rule for validating one or more OS images

--- a/chart/validator-plugin-maas/crds/validation.spectrocloud.labs_maasvalidators.yaml
+++ b/chart/validator-plugin-maas/crds/validation.spectrocloud.labs_maasvalidators.yaml
@@ -45,11 +45,11 @@ spec:
                 properties:
                   secretName:
                     type: string
-                  token:
+                  tokenKey:
                     type: string
                 required:
                 - secretName
-                - token
+                - tokenKey
                 type: object
               host:
                 description: Host is the URL for your MAAS Instance

--- a/config/crd/bases/validation.spectrocloud.labs_maasvalidators.yaml
+++ b/config/crd/bases/validation.spectrocloud.labs_maasvalidators.yaml
@@ -45,11 +45,11 @@ spec:
                 properties:
                   secretName:
                     type: string
-                  token:
+                  tokenKey:
                     type: string
                 required:
                 - secretName
-                - token
+                - tokenKey
                 type: object
               host:
                 description: Host is the URL for your MAAS Instance

--- a/config/samples/maas-credentials.yaml
+++ b/config/samples/maas-credentials.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Secret
 type: Opaque
-data:
-  MAAS_API_KEY: <your-api-key-base64-encoded>
+stringData:
+  MAAS_API_KEY: <your-api-key>
 metadata:
-  name: maas-credntials
+  name: maas-creds
   namespace: validator

--- a/config/samples/maasvalidator-osimages.yaml
+++ b/config/samples/maasvalidator-osimages.yaml
@@ -6,8 +6,8 @@ spec:
   host: "http://maas.sc:5240/MAAS"
   auth:
     # You have to specify credentials secret
-    secretName: maas-credentials
-    token: "foo" # reads token from cluster secret
+    secretName: maas-creds
+    tokenKey: "MAAS_API_KEY"
   imageRules:  
     - name: "OS Rule 1"
       images:

--- a/config/samples/maasvalidator-resources.yaml
+++ b/config/samples/maasvalidator-resources.yaml
@@ -6,8 +6,8 @@ spec:
   host: "http://maas.sc:5240/MAAS"
   auth:
     # You have to specify credentials secret
-    secretName: maas-credentials
-    token: "foo" # reads token from cluster secret
+    secretName: maas-creds
+    tokenKey: "MAAS_API_KEY"
   resourceAvailabilityRules:  
     - name: "AZ1 Rule 1" # expect pass
       az: "az1"

--- a/config/samples/maasvalidator-sample.yaml
+++ b/config/samples/maasvalidator-sample.yaml
@@ -19,22 +19,21 @@ spec:
           - type: "A"
             ip: "10.11.130.183"
             ttl: 10
-    - maasDomain: "maas.sc"
-      dnsResources:
-        - fqdn: "am-ubuntu-0c36d8.maas.sc"
-          dnsRecords:
-          - type: "A"
-            ip: "10.11.130.176"
-            ttl: 10
-          - type: "A"
-            ip: "10.11.130.183"
-            ttl: 10
-          - type: "A"
-            ip: "10.11.130.192"
-            ttl: 10
-          - type: "A"
-            ip: "10.11.130.193"
-            ttl: 10
   upstreamDNSRules:
     - name: "Upstream DNS Rule 1"
       numDNSServers: 1
+  imageRules:
+    - name: Image Rule
+      images:
+        - name: ubuntu/focal
+          architecture: amd64/ga-20.04
+        - name: ubuntu/jammy
+          architecture: amd64/ga-22.04
+  resourceAvailabilityRules:  
+    - name: "AZ1 Rule 1" # expect pass
+      az: "az1"
+      resources:
+        - numMachines: 1
+          numCPU: 16
+          ram: 16
+          disk: 100


### PR DESCRIPTION
## Issue

## Description
- switch to user configured token key instead of hard-coded
- update sample charts
- add another sample, with 4 passing rules