### PR TITLE
fix: embedding structs related to `validationrule.Interface`

### DIFF
--- a/api/v1alpha1/maasvalidator_types.go
+++ b/api/v1alpha1/maasvalidator_types.go
@@ -56,7 +56,7 @@ type Auth struct {
 
 // ImageRule defines a rule for validating one or more OS images
 type ImageRule struct {
-	validationrule.ManuallyNamed `json:"-"`
+	validationrule.ManuallyNamed `json:",inline"`
 
 	// Unique name for the rule
 	RuleName string `json:"name" yaml:"name"`
@@ -86,7 +86,7 @@ type Image struct {
 
 // InternalDNSRule provides rules for the internal DNS server
 type InternalDNSRule struct {
-	validationrule.AutomaticallyNamed `json:"-"`
+	validationrule.AutomaticallyNamed `json:",inline"`
 
 	// The domain name for the internal DNS server
 	MaasDomain string `json:"maasDomain" yaml:"maasDomain"`
@@ -121,7 +121,7 @@ type DNSRecord struct {
 
 // UpstreamDNSRule provides rules for validating the external DNS server
 type UpstreamDNSRule struct {
-	validationrule.ManuallyNamed `json:"-"`
+	validationrule.ManuallyNamed `json:",inline"`
 
 	// Unique name for the rule
 	RuleName string `json:"name" yaml:"name"`
@@ -143,7 +143,7 @@ func (r *UpstreamDNSRule) SetName(name string) {
 
 // ResourceAvailabilityRule provides rules for validating resource availability
 type ResourceAvailabilityRule struct {
-	validationrule.ManuallyNamed `json:"-"`
+	validationrule.ManuallyNamed `json:",inline"`
 
 	// Unique name for the rule
 	RuleName string `json:"name" yaml:"name"`


### PR DESCRIPTION
## Description
Noticed when trying to integrate latest plugin releases with validatorctl that tests started failing because the CRD couldn't be applied. It complained about unknown fields. This is because the json tag used when embedding the struct lacked "inline". This fixes that.