### PR TITLE
fix: YAML rendering of structs embedded in rules

### DIFF
--- a/api/v1alpha1/maasvalidator_types.go
+++ b/api/v1alpha1/maasvalidator_types.go
@@ -59,7 +59,7 @@ type Auth struct {
 
 // ImageRule defines a rule for validating one or more OS images
 type ImageRule struct {
-	validationrule.ManuallyNamed `json:",inline"`
+	validationrule.ManuallyNamed `json:",inline" yaml:",omitempty"`
 
 	// Unique name for the rule
 	RuleName string `json:"name" yaml:"name"`
@@ -89,7 +89,7 @@ type Image struct {
 
 // InternalDNSRule provides rules for the internal DNS server
 type InternalDNSRule struct {
-	validationrule.AutomaticallyNamed `json:",inline"`
+	validationrule.AutomaticallyNamed `json:",inline" yaml:",omitempty"`
 
 	// The domain name for the internal DNS server
 	MaasDomain string `json:"maasDomain" yaml:"maasDomain"`
@@ -124,7 +124,7 @@ type DNSRecord struct {
 
 // UpstreamDNSRule provides rules for validating the external DNS server
 type UpstreamDNSRule struct {
-	validationrule.ManuallyNamed `json:",inline"`
+	validationrule.ManuallyNamed `json:",inline" yaml:",omitempty"`
 
 	// Unique name for the rule
 	RuleName string `json:"name" yaml:"name"`
@@ -146,7 +146,7 @@ func (r *UpstreamDNSRule) SetName(name string) {
 
 // ResourceAvailabilityRule provides rules for validating resource availability
 type ResourceAvailabilityRule struct {
-	validationrule.ManuallyNamed `json:",inline"`
+	validationrule.ManuallyNamed `json:",inline" yaml:",omitempty"`
 
 	// Unique name for the rule
 	RuleName string `json:"name" yaml:"name"`


### PR DESCRIPTION
## Description
In previous PRs, we made the plugin rules implement the new `validationrule.Interface` interface. We did not include YAML tags in rules to specify that the new field (`validationrule.ManuallyNamed` or `validationrule.AutomaticallyNamed` depending on the rule) should not be included when the rules are rendered to YAML. The validatorctl CLI renders the rules to YAML as part of what it does, so this caused errors when validatorctl tried to apply validator CRDs it generated to its cluster.