### PR TITLE
chore: add retract directive for versions v0.0.8-v0.0.10, release 0.0.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,12 @@ module github.com/validator-labs/validator-plugin-maas
 
 go 1.22.5
 
+retract (
+	// Versions published more than once, so the latest "versions" of these
+	// versions cannot be accessed when using the Go module mirror.
+	[v0.0.8, v0.0.10]
+)
+
 require (
 	github.com/canonical/gomaasclient v0.7.0
 	github.com/deckarep/golang-set/v2 v2.6.0

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,9 @@ module github.com/validator-labs/validator-plugin-maas
 
 go 1.22.5
 
-retract (
-	// Versions published more than once, so the latest "versions" of these
-	// versions cannot be accessed when using the Go module mirror.
-	[v0.0.8, v0.0.10]
-)
+// Versions published more than once, so the latest "versions" of these
+// versions cannot be accessed when using the Go module mirror.
+retract [v0.0.8, v0.0.10]
 
 require (
 	github.com/canonical/gomaasclient v0.7.0


### PR DESCRIPTION
## Description
This will ensure that when version 0.0.11 is published by release-please, no one ever accidentally uses the corrupt versions.

Also, commit messages in this PR also should cause release-please to choose 0.0.11 as the next version it releases.
